### PR TITLE
Update package-lock.json

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6258,8 +6258,8 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "merge-descriptors": {


### PR DESCRIPTION
Fix Security Issue Advised by Github. Dependency in /client/package.json-lock. Merge 1.2.0 to Merge 1.2.1